### PR TITLE
Admin page redesign

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -204,4 +204,10 @@ class AdminController extends Controller
         $box->delete();
         return redirect()->route('admin.inventory');
     }
+
+    // Increase box stock function
+    public function addInventory(Box $box){
+        $box->increment('stock');
+        return back()->with('success', 'Stock increased successfully');
+    }
 }

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -187,17 +187,26 @@ class AdminController extends Controller
             'price' => $attributes['price'],
             'type' => $attributes['type'],
             'description' => $attributes['description'],
-                ]);
+        ]);
         $box->save();
 
         $folderName = str_replace(' ', '_', $box->title);
         $dirPath = public_path('images/Boxes/' . $folderName);
-        mkdir($dirPath, 0777, true);
+
+        // Check if directory already exists
+        if (!is_dir($dirPath)) {
+            mkdir($dirPath, 0777, true);
+        }
+
+        // Check if cover image is uploaded
         if($request->hasFile('cover')){
             $request->file('cover')->move( $dirPath, time() . '.' . $request->cover->extension());
         }
-        
-        return redirect()->route('inventory.edit',$box->id);
+
+        // Update tags
+        $box->tags()->sync($attributes['tags']);
+
+        return redirect()->route('admin.inventory.edit', $box)->with('success', 'Product edited successfully!');;
     }
 
     public function deleteBox(Box $box){

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -38,6 +38,7 @@ class UserFactory extends Factory
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'phone' => fake()->phoneNumber(),
             'remember_token' => Str::random(10),
             'pfp' => $img[array_rand($img)],
         ];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -23,13 +23,23 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        // img array
+        $img = [
+            '/images/Account/Cow.png',
+            '/images/Account/Chicken.png',
+            '/images/Account/Horse.png',
+            '/images/Account/Pig.png',
+            '/images/Account/Rabbit.png',
+            '/images/Account/Sheep.png',
+        ];
+
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
-            'pfp' => '/images/Account/cow.png'
+            'pfp' => $img[array_rand($img)],
         ];
     }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -27,7 +27,7 @@ class DatabaseSeeder extends Seeder
             'contact_preferences' => '["phone"]', // lowercase pref (email, phone) in array
             'upvotes' => 100,
             'isAdmin' => true,
-            'pfp' => '/images/Account/cow.png'
+            'pfp' => '/images/Account/Horse.png'
         ]);
         Reward::create(['user_id'=>$user->id]);
 

--- a/resources/views/admin/customers.blade.php
+++ b/resources/views/admin/customers.blade.php
@@ -63,10 +63,15 @@
                             <form method="POST" action="{{ route('update-user-role', $user->id) }}">
                                 @csrf
                                 @method('PUT')
-                                <select name="isAdmin" class="p-2 m-2 mb-0 bg-gray-100 rounded-lg" onchange="this.form.submit()">
-                                    <option value="0" {{ $user->isAdmin == 0 ? 'selected' : '' }}>User</option>
-                                    <option value="1" {{ $user->isAdmin == 1 ? 'selected' : '' }}>Admin</option>
-                                </select>
+                                <!-- User role -->
+                                @if (auth()->user()->id == $user->id)
+                                    <p class="text-red-500">You can't change your own role.</p>
+                                @else
+                                    <select name="isAdmin" class="p-2 m-2 mb-0 bg-gray-100 rounded-lg" onchange="this.form.submit()">
+                                        <option value="0" {{ $user->isAdmin == 0 ? 'selected' : '' }}>User</option>
+                                        <option value="1" {{ $user->isAdmin == 1 ? 'selected' : '' }}>Admin</option>
+                                    </select>
+                                @endif
                             </form>
                         </div>
                     </div>

--- a/resources/views/admin/customers.blade.php
+++ b/resources/views/admin/customers.blade.php
@@ -51,7 +51,7 @@
                             <div class="flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-4">
                                 <div class="w-16 h-16 rounded-full overflow-hidden">
                                     <!-- User image else default image -->
-                                    <img src="{{ $user->image ?? '/images/Account/default_chicken.png' }}" alt="{{ $user->name }}" class="w-full h-full object-cover">
+                                    <img src="{{ $user->pfp ?? '/images/Account/default_chicken.png' }}" alt="{{ $user->name }}" class="w-full h-full object-cover">
                                 </div>
                                 <div class="ml-4 text-center md:text-left">
                                     <h3 class="font-medium text-lg">{{ $user->name }}</h3>

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -12,5 +12,6 @@
         <x-admin-nav-link href="{{ route('admin.inventory') }}" :active="request()->routeIs('admin.inventory')" >Inventory Management - Products</x-admin-nav-link>
         <x-admin-nav-link href="{{ route('admin.products') }}" :active="request()->routeIs('admin.products')" >Add New Product</x-admin-nav-link>
         <x-admin-nav-link href="{{ route('admin.customers') }}" :active="request()->routeIs('admin.customers')" >Customers</x-admin-nav-link>
+        <x-admin-nav-link href="{{ route('admin.reports') }}" :active="request()->routeIs('admin.reports')" >Reports</x-admin-nav-link>
     </section>
 </x-layout>

--- a/resources/views/admin/inventory-edit.blade.php
+++ b/resources/views/admin/inventory-edit.blade.php
@@ -2,7 +2,7 @@
     <!-- Add New Product -->
     <section class="relative w-full bg-center">
         <div class="mt-16 flex flex-col items-center justify-center text-center px-4">
-            <x-account-nav-link href="{{ route('admin.index') }}" :active="request()->routeIs('admin.index')">Back</x-account-nav-link>              
+            <x-account-nav-link href="{{ route('admin.inventory') }}" :active="request()->routeIs('admin.inventory')">Back</x-account-nav-link>              
             <x-success-alert/>
             <h1 class="font-medium text-3xl md:text-5xl text-secondary">Edit Product</h1>
         </div>

--- a/resources/views/admin/inventory-edit.blade.php
+++ b/resources/views/admin/inventory-edit.blade.php
@@ -1,88 +1,105 @@
 <x-layout>
-    <!-- Add New Product -->
+    <!-- Edit product -->
     <section class="relative w-full bg-center">
         <div class="mt-16 flex flex-col items-center justify-center text-center px-4">
             <x-account-nav-link href="{{ route('admin.inventory') }}" :active="request()->routeIs('admin.inventory')">Back</x-account-nav-link>              
-            <x-success-alert/>
             <h1 class="font-medium text-3xl md:text-5xl text-secondary">Edit Product</h1>
+            <x-success-alert/>
         </div>
     </section>
-    <!-- Form -->
-    <section class="gap-4 p-6 max-w-4xl mx-auto text-center">
-        <div class=" bg-gray-50 p-4 font-medium text-lg rounded-lg flex flex-col items-center">
-            <form action="" method="POST" class="flex flex-col gap-4 w-full items-center" enctype="multipart/form-data">
+    
+    <!-- Edit -->
+    <section class="gap-4 p-6 max-w-4xl mx-auto">
+        <div class="max-h-[800px] space-y-4 p-4 bg-gray-50 rounded-lg shadow-md">
+            <form action="{{ route('admin.inventory.edit', $box) }}" method="POST" enctype="multipart/form-data">
                 @csrf
-                <!-- Product Name -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Product Name</strong></p></div>
-                    <input name="title" type="text" class="w-full px-3 py-2 bg-gray-100 rounded-md text-center" value="{{ $box->title }}" placeholder="Enter the product name..." required>
-                    <x-form-error name="title"/>
-                </div>
-                <!-- Stock Level -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Stock Level</strong></p></div>
-                    <input name="stock" type="number" class="w-full px-3 py-2 bg-gray-100 rounded-md text-center" value="{{ $box->stock }}" placeholder="0" min="1" max="100" required>
-                    <x-form-error name="stock"/>
-                </div>
-                <!-- Product Price -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Price</strong></p></div>
-                    <input name="price" type="number" step="0.01" class="w-full px-3 py-2 bg-gray-100 rounded-md text-center" value="{{ $box->price }}" placeholder="£0" min="1" max="100" required>
-                    <x-form-error name="price"/>
-                </div>
-                <!-- Box Contents | title | type | price | description | image 
-                
-                Categories - Seasonal, meat & diary, dynamic pricing, locally sourced, cultural recipe
-                Filter options - summer, green, low fat, high fat, fiber rich, fruit, veggies, british
-                -->
-                <!-- Categories -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Category</strong></p></div>
-                    <select id="category" name="type" class="w-full px-3 py-2 bg-gray-100 rounded-md text-center" required>
-                        @foreach ($types as $type)
-                        @if ($type == $box->type)
-                        <option selected value="{{ $type }}">{{ $type }}</option>
-                        @else
-                        <option value="{{ $type }}">{{ $type }}</option>
-                        @endif
-                        @endforeach
-                    </select>
-                    <x-form-error name="type"/>
-                </div>
-                <!-- Tags -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Tags</strong></p></div>
-                    <div class="w-full bg-gray-100 rounded-md px-3 py-2 text-center">
-                        @foreach ($tags as $tag )
-                        <label class="flex items-center gap-2">
-                            <input {{ $box->tags->contains($tag) ? 'checked' : '' }} type="checkbox" name="tags[]" value="{{ $tag->id }}">{{ $tag->name }} 
-                        </label>
-                        @endforeach
-                        <x-form-error name="tags"/>
+                <div class="flex flex-col md:flex-row items-center md:items-start space-y-4 md:space-y-0 md:space-x-8">
+                    <!-- Image -->
+                    <div class="w-full sm:w-80 md:w-60 lg:w-80 flex flex-col space-y-4">
+                        <div class="h-40 md:h-40 lg:h-60 rounded-md overflow-hidden flex-shrink-0">
+                            <img src="{{ $box->getImages()[0] }}" alt="{{ $box->title }}" class="w-full h-full object-cover rounded-md">
+                        </div>
+                        <div class="w-full">
+                            <input name="cover" type="file" accept="image/*" class="w-full text-sm px-3 py-2 bg-gray-100 rounded-md">
+                            <x-form-error name="cover"/>
+                        </div>
+                        <div class="w-full mt-auto">
+                            <button type="submit" class="w-full mb-2 bg-primary text-white px-4 py-2 rounded-lg font-bold hover:bg-accent1 transition-colors">Save Changes</button>
+                            <button type="submit" form="delete-form" class="w-full bg-red-500 text-white px-4 py-2 rounded-lg font-bold hover:bg-accent1 transition-colors">Delete Product</button>
+                        </div>
+                    </div>
+                    
+                    <!-- Form -->
+                    <div class="w-full space-y-4">
+                        <!-- Title -->
+                        <div class="flex items-center w-full gap-2">
+                            <div class="w-16 font-semibold flex-shrink-0">Title</div>
+                            <input name="title" type="text" value="{{ $box->title }}" 
+                                placeholder="Enter product name..." required
+                                class="w-full px-3 py-2 bg-gray-100 rounded-md">
+                            <x-form-error name="title"/>
+                        </div>
+                        
+                        <!-- Price -->
+                        <div class="flex items-center w-full gap-2">
+                            <div class="w-16 font-semibold flex-shrink-0">Price</div>
+                            <div class="relative w-full">
+                                <span class="absolute left-3 top-1/2 -translate-y-1/2">£</span>
+                                <input name="price" type="number" step="0.01" value="{{ $box->price }}" placeholder="0.00" min="1" max="100" required class="w-full px-3 py-2 pl-8 bg-gray-100 rounded-md">
+                            </div>
+                            <x-form-error name="price"/>
+                        </div>
+                        
+                        <!-- Tags -->
+                        <div class="flex items-start w-full gap-2">
+                            <div class="w-16 font-semibold flex-shrink-0 pt-2">Tags</div>
+                            <div class="flex flex-wrap gap-2 w-full">
+                                @foreach ($tags as $tag)
+                                <div class="relative flex-shrink-0">
+                                    <input type="checkbox" id="tag-{{ $tag->id }}" name="tags[]" value="{{ $tag->id }}" {{ $box->tags->contains($tag) ? 'checked' : '' }} class="absolute opacity-0 w-0 h-0 peer">
+                                    <label for="tag-{{ $tag->id }}" class="flex-shrink-0 px-2 py-1 text-xs bg-gray-200 text-black rounded-md cursor-pointer block transition-colors duration-200 peer-checked:bg-primary peer-checked:text-white">
+                                        {{ $tag->name }}
+                                    </label>
+                                </div>
+                                @endforeach
+                            </div>
+                            <x-form-error name="tags"/>
+                        </div>
+                        
+                        <!-- Type -->
+                        <div class="flex items-center w-full gap-2">
+                            <div class="w-16 font-semibold flex-shrink-0">Type</div>
+                            <select name="type" class="w-full px-3 py-2 bg-gray-100 rounded-md" required>
+                                @foreach ($types as $type)
+                                    <option value="{{ $type }}" {{ $type == $box->type ? 'selected' : '' }}>
+                                        {{ $type }}
+                                    </option>
+                                @endforeach
+                            </select>
+                            <x-form-error name="type"/>
+                        </div>
+                        
+                        <!-- Stock -->
+                        <div class="flex items-center w-full gap-2">
+                            <div class="w-16 font-semibold flex-shrink-0">Stock</div>
+                            <input name="stock" type="number" value="{{ $box->stock }}" placeholder="0" min="0" max="100" required class="w-full px-3 py-2 bg-gray-100 rounded-md">
+                            <x-form-error name="stock"/>
+                        </div>
+                        
+                        <!-- Description -->
+                        <div class="flex flex-col w-full gap-2">
+                            <div class="font-semibold text-left">Description</div>
+                            <textarea name="description" rows="4" placeholder="Enter product description..." required class="w-full px-3 py-2 bg-gray-100 rounded-md resize-none" minlength="10" maxlength="280">{{ $box->description }}</textarea>
+                            <x-form-error name="description"/>
+                        </div>
                     </div>
                 </div>
-                <!-- Description -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Description</strong></p></div>
-                    <textarea id="description" name="description" class="w-full px-3 py-2 bg-gray-100 rounded-md text-center" rows="5" placeholder="Enter the product description here..." required>{{ $box->description }}</textarea>
-                    <x-form-error name="description"/>
-                </div>
-                <!-- Media -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Media</strong></p></div>
-                    <input name="cover" type="file" accept="image/*" href="" id="media" name="media" class="w-full px-3 py-2 bg-gray-100 rounded-md text-center"></input>
-                    <x-form-error name="cover"/>
-                </div>
-                <!-- Submit -->
-                <div class="w-1/2">
-                    <button type="submit" class="bg-primary text-white px-6 py-3 rounded-lg font-bold hover:bg-accent1">Submit</button>
-                </div>
             </form>
-
-            <form action="" method="POST">
+            
+            <!-- Delete form-->
+            <form id="delete-form" action="{{ route('admin.inventory.delete', $box) }}" method="POST" class="hidden">
                 @csrf
                 @method('DELETE')
-                <button class="bg-red-600 text-white p-3 rounded hover:bg-red-500 mt-5">Delete</button>
             </form>
         </div>
     </section>

--- a/resources/views/admin/inventory.blade.php
+++ b/resources/views/admin/inventory.blade.php
@@ -1,35 +1,4 @@
-<x-layout>
-    <section>
-        @php
-            $lowStock = $boxes->where('stock', '<', 5)->count(); // Low stock
-            $outOfStock = $boxes->where('stock', '==', 0)->count(); // Out of stock
-    
-            // Change background colour
-            $bg = $outOfStock > 0 ? 'bg-red-500' : ($lowStock > 0 ? 'bg-amber-500' : 'bg-orange-400');
-        @endphp
-    
-        <div class="{{ $bg }} p-4 w-full">
-            @if ($lowStock > 0)
-                @if ($outOfStock > 0)
-                    <h1 class="font-bold text-3xl text-white text-center">Out of stock!</h1>
-                @elseif ($lowStock > 0)
-                    <h1 class="font-bold text-3xl text-white text-center">Low Stock</h1>
-                @endif
-            @endif
-    
-            @foreach ($boxes as $box)
-                <div class="text-center">
-                    @if ($box->stock < 5)
-                        <div class="flex flex-row justify-center">
-                            <h1 class="font-bold">{{ $box->title }}</h1>
-                            <p class="ml-2">{{ $box->stock }}</p>
-                        </div>
-                    @endif
-                </div>
-            @endforeach
-        </div>
-    </section>
-    
+<x-layout>    
     <!-- Order Processing List -->
     <section class="relative w-full bg-center">
         <div class="mt-16 flex flex-col items-center justify-center text-center px-4">
@@ -69,88 +38,101 @@
         </div>
     </section>
     <!-- Inventory alert -->
-    <!-- If statement 
+    <section class="space-y-4 px-4 md:px-8 lg:px-16">
+        @php
+            $lowStock = $boxes->where('stock', '>', 0)->where('stock', '<', 5)->count();
+            $outOfStock = $boxes->where('stock', '==', 0)->count();
+        @endphp
 
-    -- If any item reaches under 5 = section will pop up
-    -- Any 3 < item > 5 = bg-orange-500
-    -- Any 0 <= item > 3 = bg-red-500
+        <!-- Out of stock  -->
+        @if ($outOfStock > 0)
+            <div class="bg-red-500 p-4 w-full max-w-md md:max-w-lg lg:max-w-xl mx-auto rounded-lg shadow-md">
+                <h1 class="font-bold text-xl md:text-2xl lg:text-3xl text-white mb-2 text-center">Out of Stock!</h1>
+                <div class="">
+                    @foreach ($boxes as $box)
+                        @if ($box->stock == 0)
+                            <div class="flex justify-between p-1 rounded-md">
+                                <h1 class="font-bold text-white">{{ $box->title }}</h1>
+                                <p class="text-white">{{ $box->stock }}</p>
+                            </div>
+                        @endif
+                    @endforeach
+                </div>
+            </div>
+        @endif
 
-    -->
+        <!-- Low stock -->
+        @if ($lowStock > 0)
+            <div class="bg-amber-500 p-4 w-full max-w-md md:max-w-lg lg:max-w-xl mx-auto rounded-lg shadow-md">
+                <h1 class="font-bold text-xl md:text-2xl lg:text-3xl text-white mb-2 text-center">Low Stock</h1>
+                <div class="">
+                    @foreach ($boxes as $box)
+                        @if ($box->stock > 0 && $box->stock < 5)
+                            <div class="flex justify-between p-1 rounded-md">
+                                <h1 class="font-bold text-white">{{ $box->title }}</h1>
+                                <p class="text-white">{{ $box->stock }}</p>
+                            </div>
+                        @endif
+                    @endforeach
+                </div>
+            </div>
+        @endif
+    </section>
 
-
+    
     <!-- Display Boxes -->
-    <section class="gap-4 p-6 max-w-4xl mx-auto overflow-y-auto">
+    <section class="gap-4 p-6 pb-8 max-w-4xl mx-auto overflow-y-auto">
         <div class="max-h-[600px] overflow-y-auto space-y-4 p-2">
-            <!-- Box -->
             @foreach ($boxes as $box)
             <!-- Box Card -->
             <section class="gap-4 p-6 max-w-4xl mx-auto">
-                <div class="max-h-[600px] space-y-4 p-2 bg-gray-50 rounded-lg">
-                    <div class="flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-16 ">
-                        <div class="w-full h-full rounded-md  sm:w-80 sm:h-30 md:w-50 md:h-50">
-                            <!-- User image else default image -->
-                            <img src="{{ $box->getImages()[0] }}" alt="{{ $box->title }}" class="w-full h-full object-cover">
+                <div class="max-h-[600px] space-y-4 p-4 bg-gray-50 rounded-lg shadow-md">
+                    <div class="flex flex-col md:flex-row items-center md:items-start space-y-4 md:space-y-0 md:space-x-8">
+                        <!-- Image Section -->
+                        <div class="w-full sm:w-80 md:w-60 lg:w-80 h-40 md:h-40 lg:h-60 rounded-md overflow-hidden flex-shrink-0">
+                            <img src="{{ $box->getImages()[0] }}" alt="{{ $box->title }}" class="w-full h-full object-cover rounded-md">
                         </div>
-                        <div class="ml-4 text-center md:text-left">
-                            <h3 class="text-lg text-primary font-bold">{{ $box->title }}</h3>
-                            <p class="text-gray-500" class="text-overflow">{{ $box->description }}</p>
-                            <div class="flex items-center mt-2">
-                                <div class="w-36 flex items-center"><p><strong>Tags</strong></p></div>
-                                <?php
-                                $tags ="";
-                                foreach ($box->tags as $tag) {
-                                    $tags .=$tag->name.", ";
-                                }
-                                $tags = rtrim($tags, ", ");
-                                ?>
-                                <input type="text" value="{{$tags}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled>
+                        <!-- Content Section -->
+                        <div class="w-full text-center md:text-left">
+                            <div class="flex flex-row justify-between items-center">
+                                <h3 class="text-lg text-primary font-bold">{{ $box->title }}</h3>
+                                <a href="{{ route('inventory.edit', $box->id) }}" class="p-2">
+                                    <img src="/images/Edit.png" alt="Edit icon" class="h-5 sm:h-6 hover:opacity-75 w-5 sm:w-6">
+                                </a>
+                            </div>
+                            <p class="text-gray-500 text-sm line-clamp-2 break-words w-full">{{ $box->description }}</p>
+                            <!-- Price -->
+                            <div class="flex items-center mt-2 w-full gap-2">
+                                <div class="w-16 font-semibold flex-shrink-0">Price</div>
+                                <input type="text" value="£{{ $box->price }}" 
+                                    class="w-full px-3 py-2 bg-gray-100 rounded-md" disabled>
+                            </div>
+                            <!-- Tags Section -->
+                            <div class="flex items-center mt-2 w-full gap-2">
+                                <div class="w-16 font-semibold flex-shrink-0">Tags</div>
+                                <div class="flex overflow-x-auto gap-2 w-full" style="scrollbar-width: thin;">
+                                    <?php foreach ($box->tags as $tag): ?>
+                                        <input type="text" value="<?php echo htmlspecialchars($tag->name); ?>" class="flex-shrink-0 px-2 py-1 text-xs bg-gray-200 text-black rounded-md w-16" disabled>
+                                    <?php endforeach; ?>
+                                </div>
+                            </div>
+                            <!-- Type -->
+                            <div class="flex items-center mt-2 w-full gap-2">
+                                <div class="w-16 font-semibold flex-shrink-0">Type</div>
+                                <input type="text" value="{{ $box->type }}" class="w-full px-3 py-2 bg-gray-100 rounded-md" disabled>
+                            </div>
+                            <!-- Stock -->
+                            <div class="flex items-center mt-2 w-full gap-2">
+                                <div class="w-16 font-semibold flex-shrink-0">Stock</div>
+                                <div class="relative w-full">
+                                    <input type="text" value="{{ $box->stock }}" class="w-full px-3 py-2 bg-gray-100 rounded-md pr-12" disabled>
+                                    <a href="{{ route('inventory.add', $box->id) }}" class="absolute right-1 top-1/2 transform -translate-y-1/2 bg-primary hover:bg-accent1 transition-colors text-white px-3 py-1 rounded-md text-sm">+</a>
+                                </div>
                             </div>
                         </div>
                     </div>
-
-                    <!-- 
-                        <div class="flex items-center space-x-2">
-
-                            <div class="w-24 flex items-center"><p><strong>Name</strong></p></div>
-                            <input class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" type="text" value="{{ $box->title }}" disabled></input>
-                        </div>
-                        <div class="flex items-center mt-2">
-                            
-                            <div class="w-36 flex items-center"><p><strong>Description</strong></p></div>
-                            <input type="text" value="{{$box->description}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled>
-                        </div>
-                        <div class="flex items-center justify-center mt-2">
-                            
-                            <img src="{{ $box->getImages()[0] }}" alt="{{ $box->title }}" class="w-80 h-80 object-cover rounded-lg"/>
-                        </div>
-                        
-                        <div class="flex items-center mt-2">
-                            <div class="w-36 flex items-center"><p><strong>Type</strong></p></div>
-                            <input type="text" value="{{$box->type}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled>
-                        </div>
-
-                        <div class="flex items-center mt-2">
-                            <div class="w-36 flex items-center"><p><strong>Tags</strong></p></div>
-                            <?php
-                            $tags ="";
-                            foreach ($box->tags as $tag) {
-                                $tags .=$tag->name.", ";
-                            }
-                            $tags = rtrim($tags, ", ");
-                            ?>
-                            <input type="text" value="{{$tags}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled>
-                        </div>
-
-                        <div class="flex items-center mt-2">
-                            <div class="w-36 flex items-center"><p><strong>Stock</strong></p></div>
-                            <input type="text" value="{{$box->stock}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled>
-                        </div>
-                        <div class="flex justify-center w-full mt-5">
-                            <a href="{{ route("inventory.edit",$box->id) }}" class="bg-green-600 p-2 text-white rounded hover:bg-green-500 text-lg">Edit</a>
-                        </div>
-                    -->
                 </div>
-            </div>            
+            </section>
             @endforeach
         </div>
     </section>

--- a/resources/views/admin/inventory.blade.php
+++ b/resources/views/admin/inventory.blade.php
@@ -29,6 +29,7 @@
             @endforeach
         </div>
     </section>
+    
     <!-- Order Processing List -->
     <section class="relative w-full bg-center">
         <div class="mt-16 flex flex-col items-center justify-center text-center px-4">
@@ -83,48 +84,71 @@
             <!-- Box -->
             @foreach ($boxes as $box)
             <!-- Box Card -->
-            <div class="bg-gray-200 p-4 font-medium text-lg rounded-lg flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-4">
-                <!-- Box Info -->
-                <div class="flex-1 w-full">
-                    <div class="flex items-center space-x-2">
-                        <!-- Box Name -->
-                        <div class="w-24 flex items-center"><p><strong>Name</strong></p></div>
-                        <input class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" type="text" value="{{ $box->title }}" disabled></input>
+            <section class="gap-4 p-6 max-w-4xl mx-auto">
+                <div class="max-h-[600px] space-y-4 p-2 bg-gray-50 rounded-lg">
+                    <div class="flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-16 ">
+                        <div class="w-full h-full rounded-md  sm:w-80 sm:h-30 md:w-50 md:h-50">
+                            <!-- User image else default image -->
+                            <img src="{{ $box->getImages()[0] }}" alt="{{ $box->title }}" class="w-full h-full object-cover">
+                        </div>
+                        <div class="ml-4 text-center md:text-left">
+                            <h3 class="text-lg text-primary font-bold">{{ $box->title }}</h3>
+                            <p class="text-gray-500" class="text-overflow">{{ $box->description }}</p>
+                            <div class="flex items-center mt-2">
+                                <div class="w-36 flex items-center"><p><strong>Tags</strong></p></div>
+                                <?php
+                                $tags ="";
+                                foreach ($box->tags as $tag) {
+                                    $tags .=$tag->name.", ";
+                                }
+                                $tags = rtrim($tags, ", ");
+                                ?>
+                                <input type="text" value="{{$tags}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled>
+                            </div>
+                        </div>
                     </div>
-                    <div class="flex items-center mt-2">
-                        <!-- Box Description -->
-                        <div class="w-36 flex items-center"><p><strong>Description</strong></p></div>
-                        <input type="text" value="{{$box->description}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled> <!-- No order description?! -->
-                    </div>
-                    <div class="flex items-center justify-center mt-2">
-                        <!-- Box Image -->
-                        <img src="{{ $box->getImages()[0] }}" alt="{{ $box->title }}" class="w-80 h-80 object-cover rounded-lg"/>
-                    </div>
-                    <!-- Box Type -->
-                    <div class="flex items-center mt-2">
-                        <div class="w-36 flex items-center"><p><strong>Type</strong></p></div>
-                        <input type="text" value="{{$box->type}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled> <!-- No order description?! -->
-                    </div>
-                    <!-- Box Tags -->
-                    <div class="flex items-center mt-2">
-                        <div class="w-36 flex items-center"><p><strong>Tags</strong></p></div>
-                        <?php
-                        $tags ="";
-                        foreach ($box->tags as $tag) {
-                            $tags .=$tag->name.", ";
-                        }
-                        $tags = rtrim($tags, ", ");
-                        ?>
-                        <input type="text" value="{{$tags}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled> <!-- No order description?! -->
-                    </div>
-                    <!-- Box Stock -->
-                    <div class="flex items-center mt-2">
-                        <div class="w-36 flex items-center"><p><strong>Stock</strong></p></div>
-                        <input type="text" value="{{$box->stock}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled> <!-- No order description?! -->
-                    </div>
-                    <div class="flex justify-center w-full mt-5">
-                        <a href="{{ route("inventory.edit",$box->id) }}" class="bg-green-600 p-2 text-white rounded hover:bg-green-500 text-lg">Edit</a>
-                    </div>
+
+                    <!-- 
+                        <div class="flex items-center space-x-2">
+
+                            <div class="w-24 flex items-center"><p><strong>Name</strong></p></div>
+                            <input class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" type="text" value="{{ $box->title }}" disabled></input>
+                        </div>
+                        <div class="flex items-center mt-2">
+                            
+                            <div class="w-36 flex items-center"><p><strong>Description</strong></p></div>
+                            <input type="text" value="{{$box->description}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled>
+                        </div>
+                        <div class="flex items-center justify-center mt-2">
+                            
+                            <img src="{{ $box->getImages()[0] }}" alt="{{ $box->title }}" class="w-80 h-80 object-cover rounded-lg"/>
+                        </div>
+                        
+                        <div class="flex items-center mt-2">
+                            <div class="w-36 flex items-center"><p><strong>Type</strong></p></div>
+                            <input type="text" value="{{$box->type}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled>
+                        </div>
+
+                        <div class="flex items-center mt-2">
+                            <div class="w-36 flex items-center"><p><strong>Tags</strong></p></div>
+                            <?php
+                            $tags ="";
+                            foreach ($box->tags as $tag) {
+                                $tags .=$tag->name.", ";
+                            }
+                            $tags = rtrim($tags, ", ");
+                            ?>
+                            <input type="text" value="{{$tags}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled>
+                        </div>
+
+                        <div class="flex items-center mt-2">
+                            <div class="w-36 flex items-center"><p><strong>Stock</strong></p></div>
+                            <input type="text" value="{{$box->stock}}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled>
+                        </div>
+                        <div class="flex justify-center w-full mt-5">
+                            <a href="{{ route("inventory.edit",$box->id) }}" class="bg-green-600 p-2 text-white rounded hover:bg-green-500 text-lg">Edit</a>
+                        </div>
+                    -->
                 </div>
             </div>            
             @endforeach

--- a/resources/views/admin/products.blade.php
+++ b/resources/views/admin/products.blade.php
@@ -2,79 +2,110 @@
     <!-- Add New Product -->
     <section class="relative w-full bg-center">
         <div class="mt-16 flex flex-col items-center justify-center text-center px-4">
-            <x-account-nav-link href="{{ route('admin.index') }}" :active="request()->routeIs('admin.index')">Back</x-account-nav-link>              
-            <x-success-alert/>
+            <x-account-nav-link href="{{ route('admin.index') }}" :active="request()->routeIs('admin.index')">Back</x-account-nav-link>
             <h1 class="font-medium text-3xl md:text-5xl text-secondary">Add New Product</h1>
+            <x-success-alert/>
         </div>
     </section>
-    <!-- Form -->
-    <section class="gap-4 p-6 max-w-4xl mx-auto text-center">
-        <div class=" bg-gray-50 p-4 font-medium text-lg rounded-lg flex flex-col items-center">
-            <form action="" method="POST" class="flex flex-col gap-4 w-full items-center" enctype="multipart/form-data">
-                @csrf
-                <!-- Product Name -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Product Name</strong></p></div>
-                    <input name="title" type="text" class="w-full px-3 py-2 bg-gray-100 rounded-md text-center" placeholder="Enter the product name..." required>
-                    <x-form-error name="title"/>
-                </div>
-                <!-- Initial Stock Level -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Initial Stock Level</strong></p></div>
-                    <input name="stock" type="number" class="w-full px-3 py-2 bg-gray-100 rounded-md text-center" placeholder="0" min="1" max="100" required>
-                    <x-form-error name="stock"/>
-                </div>
-                <!-- Product Price -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Price</strong></p></div>
-                    <input name="price" type="number" step="0.01" class="w-full px-3 py-2 bg-gray-100 rounded-md text-center" placeholder="£0" min="1" max="100" required>
-                    <x-form-error name="price"/>
-                </div>
-                <!-- Box Contents | title | type | price | description | image 
-                
-                Categories - Seasonal, meat & diary, dynamic pricing, locally sourced, cultural recipe
-                Filter options - summer, green, low fat, high fat, fiber rich, fruit, veggies, british
-                -->
-                <!-- Categories -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Category</strong></p></div>
-                    <select id="category" name="type" class="w-full px-3 py-2 bg-gray-100 rounded-md text-center" required>
-                        @foreach ($types as $type)
-                        <option value="{{ $type }}">{{ $type }}</option>
 
-                        @endforeach
-                    </select>
-                    <x-form-error name="type"/>
-                </div>
-                <!-- Tags -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Tags</strong></p></div>
-                    <div class="w-full bg-gray-100 rounded-md px-3 py-2 text-center">
-                        @foreach ($tags as $tag )
-                        <label class="flex items-center gap-2">
-                            <input type="checkbox" name="tags[]" value="{{ $tag->id }}">{{ $tag->name }} 
-                        </label>
-                        @endforeach
-                        <x-form-error name="tags"/>
+    <!-- Form -->
+    <section class="gap-4 p-6 max-w-4xl mx-auto">
+        <div class="max-h-[800px] space-y-4 p-4 bg-gray-50 rounded-lg shadow-md">
+            <form action="" method="POST" enctype="multipart/form-data">
+                @csrf
+                <div class="flex flex-col md:flex-row items-center md:items-start space-y-4 md:space-y-0 md:space-x-8">
+                    <!-- Image -->
+                    <div class="w-full sm:w-80 md:w-60 lg:w-80 flex flex-col space-y-4">
+                        <div class="h-40 md:h-40 lg:h-60 rounded-md overflow-hidden flex-shrink-0 bg-gray-200 flex items-center justify-center">
+                            <img id="imagePreview" src="/images/Placeholder.jpeg" alt="Placeholder image" class="w-full h-full object-cover rounded-lg">
+                        </div>
+                        <div class="w-full">
+                            <input name="cover" type="file" accept="image/*" onchange="previewImage(this)" class="w-full px-3 py-2 bg-gray-100 rounded-md border text-sm border-gray-300">
+                            <x-form-error name="cover"/>
+                        </div>
+                        <div class="w-full mt-auto">
+                            <button type="submit" class="w-full bg-primary text-white px-4 py-2 rounded-lg font-bold hover:bg-accent1 transition-colors">Create Product</button>
+                        </div>
                     </div>
-                </div>
-                <!-- Description -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Description</strong></p></div>
-                    <textarea id="description" name="description" class="w-full px-3 py-2 bg-gray-100 rounded-md text-center" rows="5" placeholder="Enter the product description here..." required></textarea>
-                    <x-form-error name="description"/>
-                </div>
-                <!-- Media -->
-                <div class="w-1/2">
-                    <div class="w-full flex items-center"><p><strong>Media</strong></p></div>
-                    <input name="cover" type="file" accept="image/*" href="" id="media" name="media" class="w-full px-3 py-2 bg-gray-100 rounded-md text-center"></input>
-                    <x-form-error name="cover"/>
-                </div>
-                <!-- Submit -->
-                <div class="w-1/2">
-                    <button type="submit" class="bg-primary text-white px-6 py-3 rounded-lg font-bold hover:bg-accent1">Submit</button>
+                    
+                    <!-- Content Section -->
+                    <div class="w-full space-y-4">
+                        <!-- Title -->
+                        <div class="flex items-center w-full gap-2">
+                            <div class="w-16 font-semibold flex-shrink-0">Title</div>
+                            <input name="title" type="text" placeholder="Enter product name..." required class="w-full px-3 py-2 bg-gray-100 rounded-md border border-gray-300">
+                            <x-form-error name="title"/>
+                        </div>
+                        
+                        <!-- Price -->
+                        <div class="flex items-center w-full gap-2">
+                            <div class="w-16 font-semibold flex-shrink-0">Price</div>
+                            <div class="relative w-full">
+                                <span class="absolute left-3 top-1/2 transform -translate-y-1/2">£</span>
+                                <input name="price" type="number" step="0.1" placeholder="0.00" min="1" max="100" required class="w-full px-3 py-2 pl-8 bg-gray-100 rounded-md border border-gray-300">
+                            </div>
+                            <x-form-error name="price"/>
+                        </div>
+                        
+                        <!-- Tags -->
+                        <div class="flex items-start w-full gap-2">
+                            <div class="w-16 font-semibold flex-shrink-0 pt-2">Tags</div>
+                            <div class="flex flex-wrap gap-2 w-full">
+                                @foreach ($tags as $tag)
+                                <div class="relative flex-shrink-0">
+                                    <input type="checkbox" id="tag-{{ $tag->id }}" name="tags[]" value="{{ $tag->id }}" class="absolute opacity-0 w-0 h-0 peer">
+                                    <label for="tag-{{ $tag->id }}" class="flex-shrink-0 px-2 py-1 text-xs bg-gray-200 text-black rounded-md cursor-pointer block transition-colors duration-200 peer-checked:bg-primary peer-checked:text-white">
+                                        {{ $tag->name }}
+                                    </label>
+                                </div>
+                                @endforeach
+                            </div>
+                            <x-form-error name="tags"/>
+                        </div>
+                        
+                        <!-- Type -->
+                        <div class="flex items-center w-full gap-2">
+                            <div class="w-16 font-semibold flex-shrink-0">Type</div>
+                            <select name="type" class="w-full px-3 py-2 bg-gray-100 rounded-md border border-gray-300" required>
+                                @foreach ($types as $type)
+                                    <option value="{{ $type }}">{{ $type }}</option>
+                                @endforeach
+                            </select>
+                            <x-form-error name="type"/>
+                        </div>
+                        
+                        <!-- Stock -->
+                        <div class="flex items-center w-full gap-2">
+                            <div class="w-16 font-semibold flex-shrink-0">Stock</div>
+                            <input name="stock" type="number" placeholder="0" min="1" max="100" required class="w-full px-3 py-2 bg-gray-100 rounded-md border border-gray-300">
+                            <x-form-error name="stock"/>
+                        </div>
+                        
+                        <!-- Description -->
+                        <div class="flex flex-col w-full gap-2">
+                            <label class="font-semibold text-left">Description</label>
+                            <textarea name="description" rows="4" placeholder="Enter product description..." required class="w-full min-h-[120px] h-32 md:h-40 px-3 py-2 bg-gray-100 rounded-md border border-gray-300 resize-none" minlength="10" maxlength="280" ></textarea>
+                            <x-form-error name="description"/>
+                        </div>
+
+                    </div>
                 </div>
             </form>
         </div>
     </section>
 </x-layout>
+
+<script>
+    // Preview Image
+function previewImage(input) {
+    // Check if input has files
+    if (input.files && input.files[0]) {
+        const reader = new FileReader();
+        // Set image source to file
+        reader.onload = function(e) {
+            document.getElementById('imagePreview').src = e.target.result;
+        }
+        reader.readAsDataURL(input.files[0]);
+    }
+}
+</script>

--- a/resources/views/admin/reports.blade.php
+++ b/resources/views/admin/reports.blade.php
@@ -1,0 +1,98 @@
+<x-layout>
+    <!-- User Detail Management -->
+    <section class="relative w-full bg-center">
+        <div class="mt-16 flex flex-col items-center justify-center text-center px-4">
+            <x-account-nav-link href="{{ route('admin.index') }}" :active="request()->routeIs('admin.index')">Back</x-account-nav-link>
+            <h1 class="font-medium text-3xl md:text-5xl text-secondary mb-8">Report Dashboard</h1>
+        </div>
+    </section>
+
+    <section class="gap-4 p-6 max-w-4xl mx-auto overflow-y-auto">
+        <div class="max-h-[600px] overflow-y-auto space-y-4 p-2">
+            <!-- Users -->
+            <div class="bg-white p-6 rounded-lg shadow-md">
+                <h2 class="text-2xl font-bold mb-4 text-primary">Users</h2>
+                <p>Total Users: {{ $data["users"] ?? 0 }}</p>
+                <p>Total Administrators: {{ $data["admins"] ?? 0 }}</p>
+            </div>
+
+            <!-- Orders -->
+            <div class="bg-white p-6 rounded-lg shadow-md">
+                <h2 class="text-2xl font-bold mb- text-primary">Orders</h2>
+                <p>Total Orders: {{ $data["numberOfOrders"] ?? 0 }}</p> <!-- Number of orders -->
+                <p>Average Order Value: £{{ number_format($data["avgOrderValue"] ?? 0, 2) }}</p> <!-- Average order value -->
+                <p>Returned Orders: {{ $data["noReturnedOrders"] ?? 0 }}</p> <!-- Number of returned orders -->
+                <p>Return Rate: {{ $data["returnRate"] ?? 0 }}%</p> <!-- Return rate -->
+            </div>
+
+            <!-- Sales / revenue -->
+            <div class="bg-white p-6 rounded-lg shadow-md">
+                <h2 class="text-2xl font-bold mb-4 text-primary">Sales</h2>
+                <p>Total Revenue: £{{ number_format($data["revenue"] ?? 0, 2) }}</p> <!-- Total revenue -->
+            </div>
+
+            <!-- Inventory -->
+            <div class="bg-white p-6 rounded-lg shadow-md">
+                <h2 class="text-2xl font-bold mb-4 text-primary">Inventory</h2>
+                <p>Total Inventory Value: £{{ number_format($data["inventoryValue"] ?? 0, 2) }}</p> <!-- Total inventory value -->
+                <p>Total Inventory Items: {{ $data["inventoryItems"] ?? 0 }}</p> <!-- Total inventory items -->
+            </div>
+
+            <!-- Customer Support -->
+            <div class="bg-white p-6 rounded-lg shadow-md">
+                <h2 class="text-2xl font-bold mb-4 text-primary">Customer Support</h2>
+                <p>Total Enquiries: {{ $data["enquiries"] ?? 0 }}</p> <!-- Number of enquiries -->
+            </div>
+
+            <!-- Reviews -->
+            <div class="bg-white p-6 rounded-lg shadow-md">
+                <h2 class="text-2xl font-bold mb-4 text-primary">Product Review</h2>
+                <p>Total Product Reviews: {{ $data["boxReviews"] ?? 0 }}</p> <!-- Number of product reviews -->
+                <p>Average Product Rating: {{ number_format($data["avgBoxRating"] ?? 0, 1) }}</p> <!-- Average product rating -->
+            </div>
+
+            <!-- Site Reviews -->
+            <div class="bg-white p-6 rounded-lg shadow-md">
+                <h2 class="text-2xl font-bold mb-4 text-primary">Site Review</h2>
+                <p>Total Site Reviews: {{ $data["siteReviews"] ?? 0 }}</p> <!-- Number of site reviews -->
+                <p>Average Site Rating: {{ number_format($data["avgSiteRating"] ?? 0, 1) }}</p> <!-- Average site rating -->
+            </div>
+        </div>
+
+        <div class="flex justify-center mt-10">
+            <div class="text-center">
+                <h2 class="text-2xl font-bold mb-4 text-primary">Category Sales</h2>
+                <canvas id="categoryChart"></canvas>
+            </div>
+        </div>
+
+        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                const data = @json($data);
+
+                const categoryCtx = document.getElementById("categoryChart").getContext('2d');
+                new Chart(categoryCtx, {
+                    type: "pie",
+                    data: {
+                        labels: Object.keys(data.categorySales || {}),
+                        datasets: [{
+                            label: "# of Sales by Type",
+                            data: Object.values(data.categorySales || {}),
+                            borderWidth: 1,
+                        }],
+                    },
+                    options: {
+                        plugins: {
+                            title: {
+                                display: true,
+                                text: 'Sales by Box Type'
+                            }
+                        }
+                    },
+                });
+            });
+        </script>
+    </div>
+</x-layout>

--- a/resources/views/components/account-layout.blade.php
+++ b/resources/views/components/account-layout.blade.php
@@ -4,8 +4,13 @@
         <!-- Sidebar -->
         <aside class="w-full md:w-1/4 bg-white p-4 rounded-lg shadow-md flex flex-col items-center h-auto md:max-h-[calc(100vh-4rem)] mb-2 md:mb-0 overflow-y-auto">            
             <!-- User Info -->
-            <div class="text-center mb-6">
-                <a href="/customer/{{Auth::user()->id}}"><h2 class="text-lg font-semibold">{{ Auth::user()->name }}</h2></a>
+            <div class="flex items-center space-x-4 mb-6">
+                <a href="/customer/{{ Auth::user()->id }}" class="flex items-center space-x-4">
+                    <img src="{{ Auth::user()->pfp ?? '/images/Account/default_chicken.png' }}" 
+                        alt="{{ Auth::user()->name }}" 
+                        class="object-cover w-12 h-12 rounded-full">
+                    <h2 class="text-lg font-semibold">{{ Auth::user()->name }}</h2>
+                </a>
             </div>
 
             <!-- Navigation Links -->

--- a/resources/views/components/admin-users-item.blade.php
+++ b/resources/views/components/admin-users-item.blade.php
@@ -5,7 +5,7 @@
     <!-- Customer Image -->
     <div class="w-20 h-20 rounded-lg flex-shrink-0">
         <!-- User Image / Default pfp atm -->
-        <img src="{{ $user->image ?? '/images/Account/default_chicken.png' }}" alt="{{ $user->name }}" class="w-full h-full object-cover rounded-lg"/> 
+        <img src="{{ $user->pfp ?? '/images/Account/default_chicken.png' }}" alt="{{ $user->name }}" class="w-full h-full object-cover rounded-lg"/> 
     </div>
     <!-- Customer Info -->
     <div class="flex-1 w-full">

--- a/resources/views/components/admin-users-item.blade.php
+++ b/resources/views/components/admin-users-item.blade.php
@@ -3,106 +3,126 @@
 <!-- User Card -->
 <div class="bg-gray-50 p-4 font-medium text-lg rounded-lg flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-4">
     <!-- Customer Image -->
-    <div class="w-20 h-20 rounded-lg flex-shrink-0">
-        <!-- User Image / Default pfp atm -->
-        <img src="{{ $user->pfp ?? '/images/Account/default_chicken.png' }}" alt="{{ $user->name }}" class="w-full h-full object-cover rounded-lg"/> 
+    <div class="flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-4">
+        <div class="w-16 h-16 rounded-full overflow-hidden">
+            <!-- User image else default image -->
+            <img src="{{ $user->pfp ?? '/images/Account/default_chicken.png' }}" 
+                alt="{{ $user->name }}" 
+                class="w-full h-full object-cover">
+        </div>
+        <div class="text-center md:text-left">
+            <h3 class="font-medium text-lg">{{ $user->name }}</h3>
+            <p class="text-gray-500">{{ $user->email }}</p>
+        </div>
     </div>
+
     <!-- Customer Info -->
-    <div class="flex-1 w-full">
-        <!-- Email -->
-        <input type="text" value="{{ $user->email }}" class="w-full px-3 py-2 bg-gray-100 rounded-md" disabled>
-        <!-- Name -->
-        <input type="text" value="{{ $user->name }}" class="w-full mt-2 px-3 py-2 bg-gray-100 rounded-md" disabled>
+    <div class="w-full mt-4 flex flex-col md:flex-row md:justify-end">
         <!-- Buttons -->
-        <div class="flex flex-col md:flex-row justify-between mt-4 space-y-2 md:space-y-0">
-            <button class="w-full md:w-1/2 bg-gray-100 rounded-lg py-2 text-center" onclick="viewOrders({{ $user->id }})">Personal Order History</button>
-            <button class="w-full md:w-1/4 bg-gray-100 rounded-lg py-2 text-center" onclick="viewUserInfo({{ $user->id }})">Expand Info</button>
+        <div class="flex flex-col md:flex-row space-y-2 md:space-y-0 md:space-x-4">
+            <button class="bg-gray-100 rounded-lg py-2 px-4 w-full md:w-auto" 
+                    onclick="viewOrders({{ $user->id }})">
+                Personal Order History
+            </button>
+            <button class="bg-gray-100 rounded-lg py-2 px-4 w-full md:w-auto" 
+                    onclick="viewUserInfo({{ $user->id }})">
+                Expand Info
+            </button>
         </div>
     </div>
-    
-    <div id="info_{{ $user->id }}" class="hidden bg-[#000000e0] fixed top-[12%] w-[80%] h-[80%] max-w-[900px] max-h-[600px] left-1/2 transform -translate-x-1/2 rounded-lg shadow-2xl text-white overflow-y-auto p-8 animate-fade-in">
-        <!-- Close Button -->
-        <button class="absolute top-4 right-4 text-gray-400 hover:text-red-500 text-3xl font-bold focus:outline-none" onclick="closeInfo({{ $user->id }})">✕</button>
-    
-        <!-- Title -->
-        <h2 class="text-3xl font-extrabold mb-6 text-primary border-b border-gray-700 pb-2">User Information</h2>
-    
-        <!-- User Details -->
-        <div class="space-y-4 text-lg">
-            <h3 class="text-2xl font-bold mb-2">Details</h3>
-            <div class="flex justify-between">
-                <span class="font-semibold">Name:</span>
-                <span>{{ $user->name }}</span>
-            </div>
-            <div class="flex justify-between">
-                <span class="font-semibold">Email:</span>
-                <span>{{ $user->email }}</span>
-            </div>
-            <div class="flex justify-between">
-                <span class="font-semibold">Phone:</span>
-                <span>{{ $user->phone }}</span>
-            </div>
-            <div class="flex justify-between">
-                <span class="font-semibold">Joined:</span>
-                <span>{{ $user->created_at->format('j F, Y') }}</span>
-            </div>
 
-            <div class="mt-6">
-                <h3 class="text-2xl font-bold mb-2">Addresses</h3>
-                <div class="space-y-2">
-                    @foreach($user->addresses as $address)
-                        <div class="p-4">
-                            <p><span class="font-semibold text-primary">Address Line 1:</span> {{ $address->address }}</p>
-                            <p><span class="font-semibold  text-primary">City:</span> {{ $address->city }}</p>
-                            <p><span class="font-semibold  text-primary">Country:</span> {{ $address->country }}</p>
-                            <p><span class="font-semibold  text-primary">Postal Code:</span> {{ $address->postcode }}</p>
-                        </div>
-                    @endforeach
+    <!-- Expand Info | User Information -->
+    <div id="info_{{ $user->id }}" class="hidden fixed inset-0 flex items-center justify-center">
+        <div class="bg-white w-[90%] md:max-w-[900px] h-auto max-h-[80vh] overflow-y-auto rounded-xl shadow-lg p-6 relative">
+            <!-- Close Button -->
+            <button class="absolute top-4 right-4 text-secondary hover:text-primary text-3xl font-bold focus:outline-none" onclick="closeInfo({{ $user->id }})">✕</button>
+
+            <!-- Title -->
+            <h2 class="text-2xl md:text-3xl font-extrabold mb-4 text-primary border-b border-gray-300 pb-2">
+                User Information
+            </h2>
+
+            <!-- User Details -->
+            <div class="space-y-4 text-lg text-text">
+                <h3 class="text-xl font-bold mb-2 text-secondary">Details</h3>
+                
+                <div class="flex justify-between border-b border-gray-200 pb-2">
+                    <span class="font-semibold">Name:</span>
+                    <span>{{ $user->name }}</span>
                 </div>
-            </div>
-        </div>
-    </div>
-    <div id="orders_{{ $user->id }}" class="hidden bg-[#000000e0] fixed top-[12%] w-[80%] h-[80%] max-w-[900px] max-h-[600px] left-1/2 transform -translate-x-1/2 rounded-lg shadow-2xl text-white overflow-y-auto p-8 animate-fade-in">
-        <!-- Close Button -->
-        <button class="absolute top-4 right-4 text-gray-400 hover:text-red-500 text-3xl font-bold focus:outline-none" onclick="closeOrders({{ $user->id }})">✕</button>
-
-        <!-- Title -->
-        <h2 class="text-3xl font-extrabold mb-6 text-primary border-b border-gray-700 pb-2">User Information</h2>
-
-        <!-- Order Details -->
-        <div class="overflow-y-auto h-[428px] space-y-4">
-            @foreach ($user->orders as $order)
-            <div class="bg-white border rounded-lg shadow-md p-4">
-                <div class="mb-2">
-                    <span class="text-lg font-bold text-primary">Order Number: {{ $order->id }}</span>
-                    <span class="text-sm text-gray-500">({{ $order->created_at->format('j F, Y') }})</span>
+                <div class="flex justify-between border-b border-gray-200 pb-2">
+                    <span class="font-semibold">Email:</span>
+                    <span>{{ $user->email }}</span>
                 </div>
-                <div>
-                    <h3 class=" font-[550] text-secondary text-lg">Items Ordered:</h3>
-                    <ul class="list-disc list-inside ml-4">
-                        @foreach ($order->itemOrders as $item)
-                            <li class="text-gray-600">
-                                <span class="font-semibold">{{ $item->box->title }}</span>
-                                <span class="text-sm text-gray-500"> - Quantity: {{ $item->quantity }}</span>
-                            </li>
+                <div class="flex justify-between border-b border-gray-200 pb-2">
+                    <span class="font-semibold">Phone:</span>
+                    <span>{{ $user->phone }}</span>
+                </div>
+                <div class="flex justify-between border-b border-gray-200 pb-2">
+                    <span class="font-semibold">Joined:</span>
+                    <span>{{ $user->created_at->format('j F, Y') }}</span>
+                </div>
+
+                <!-- Addresses Section -->
+                <div class="mt-6">
+                    <h3 class="text-xl font-bold mb-2 text-secondary">Addresses</h3>
+                    <div class="space-y-4">
+                        @foreach($user->addresses as $address)
+                            <div class="bg-accent2/10 p-4 rounded-lg shadow-sm border-l-4 border-accent2">
+                                <p><span class="font-semibold text-secondary">Address Line 1:</span> {{ $address->address }}</p>
+                                <p><span class="font-semibold text-secondary">City:</span> {{ $address->city }}</p>
+                                <p><span class="font-semibold text-secondary">Country:</span> {{ $address->country }}</p>
+                                <p><span class="font-semibold text-secondary">Postal Code:</span> {{ $address->postcode }}</p>
+                            </div>
                         @endforeach
-                    </ul>
-                </div>
-                <div class="mt-4">
-                    <p class="text-sm text-gray-500">
-                        <span class="font-semibold">Status:</span> 
-                        {{ $order->status }}
-                    </p>
-                    <p class="text-sm text-gray-500">
-                        <span class="font-semibold">Shipping Address:</span> 
-                        {{ $order->address }}, {{ $order->city }}, {{ $order->postcode }}, {{ $order->country }}
-                    </p>
-                    <p class="text-sm text-gray-500">
-                        <span class="font-semibold">Total:</span> £{{ number_format($order->total, 2) }}
-                    </p>
+                    </div>
                 </div>
             </div>
-        @endforeach
         </div>
     </div>
+
+    <!-- Personal Order History -->
+    <div id="orders_{{ $user->id }}" class="hidden fixed inset-0 flex items-center justify-center">
+        <div class="bg-white w-[90%] md:max-w-[900px] h-auto max-h-[80vh] overflow-hidden rounded-xl shadow-lg p-6 relative">
+            <!-- Close Button -->
+            <button class="absolute top-4 right-4 text-secondary hover:text-primary text-3xl font-bold focus:outline-none" onclick="closeOrders({{ $user->id }})">
+                ✕
+            </button>
+
+            <!-- Title -->
+            <h2 class="text-2xl md:text-3xl font-extrabold mb-4 text-primary border-b border-gray-300 pb-2">
+                Personal Order History
+            </h2>
+
+            <!-- Scrollable Order Details -->
+            <div class="space-y-4 max-h-[50vh] overflow-y-auto pr-2">
+                @foreach ($user->orders as $order)
+                    <div class="bg-gray-100 p-4 rounded-lg shadow-sm border-l-4 border-accent2">
+                        <div class="mb-2">
+                            <span class="text-lg font-bold text-primary">Order Number: {{ $order->id }}</span>
+                            <span class="text-sm text-gray-500">({{ $order->created_at->format('j F, Y') }})</span>
+                        </div>
+                        <div>
+                            <h3 class="font-medium text-secondary text-lg">Items Ordered:</h3>
+                            <ul class="list-disc list-inside ml-4">
+                                @foreach ($order->itemOrders as $item)
+                                    <li class="text-gray-600">
+                                        <span class="font-semibold">{{ $item->box->title }}</span>
+                                        <span class="text-sm text-gray-500"> - Quantity: {{ $item->quantity }}</span>
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                        <div class="mt-4 text-sm text-gray-700">
+                            <p><span class="font-semibold">Status:</span> {{ $order->status }}</p>
+                            <p><span class="font-semibold">Shipping Address:</span> {{ $order->address }}, {{ $order->city }}, {{ $order->postcode }}, {{ $order->country }}</p>
+                            <p><span class="font-semibold">Total:</span> £{{ number_format($order->total, 2) }}</p>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </div>
+
+
 </div>

--- a/resources/views/components/admin-users-item.blade.php
+++ b/resources/views/components/admin-users-item.blade.php
@@ -6,9 +6,7 @@
     <div class="flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-4">
         <div class="w-16 h-16 rounded-full overflow-hidden">
             <!-- User image else default image -->
-            <img src="{{ $user->pfp ?? '/images/Account/default_chicken.png' }}" 
-                alt="{{ $user->name }}" 
-                class="w-full h-full object-cover">
+            <img src="{{ $user->pfp ?? '/images/Account/default_chicken.png' }}" alt="{{ $user->name }}" class="w-full h-full object-cover">
         </div>
         <div class="text-center md:text-left">
             <h3 class="font-medium text-lg">{{ $user->name }}</h3>
@@ -20,14 +18,8 @@
     <div class="w-full mt-4 flex flex-col md:flex-row md:justify-end">
         <!-- Buttons -->
         <div class="flex flex-col md:flex-row space-y-2 md:space-y-0 md:space-x-4">
-            <button class="bg-gray-100 rounded-lg py-2 px-4 w-full md:w-auto" 
-                    onclick="viewOrders({{ $user->id }})">
-                Personal Order History
-            </button>
-            <button class="bg-gray-100 rounded-lg py-2 px-4 w-full md:w-auto" 
-                    onclick="viewUserInfo({{ $user->id }})">
-                Expand Info
-            </button>
+            <button class="bg-gray-100 rounded-lg py-2 px-4 w-full md:w-auto" onclick="viewOrders({{ $user->id }})">Personal Order History</button>
+            <button class="bg-gray-100 rounded-lg py-2 px-4 w-full md:w-auto" onclick="viewUserInfo({{ $user->id }})">Expand Info</button>
         </div>
     </div>
 

--- a/resources/views/customer/show.blade.php
+++ b/resources/views/customer/show.blade.php
@@ -6,7 +6,7 @@
         <div class="flex flex-col sm:flex-row items-start sm:items-center space-y-4 sm:space-y-0 sm:space-x-4 mt-4 bg-gray-50 p-3 sm:p-4 rounded-lg">
             <!-- User image -->
             <div class="w-12 h-12 sm:w-16 sm:h-16 rounded-full overflow-hidden flex-shrink-0">
-                <img src="{{ $user->image ?? '/images/Account/default_chicken.png' }}" alt="{{ $user->name }}" class="w-full h-full object-cover">
+                <img src="{{ $user->pfp ?? '/images/Account/default_chicken.png' }}" alt="{{ $user->name }}" class="w-full h-full object-cover">
             </div>
 
             <div class="flex-1">

--- a/routes/web.php
+++ b/routes/web.php
@@ -145,9 +145,9 @@ Route::middleware(IsAdmin::class)->controller(AdminController::class)->group(fun
     Route::patch('/admin/orders','updateOrderStatus');
     Route::get('/admin/products', 'products')->name('admin.products');
     Route::post('/admin/products','addProduct');
-    Route::post('/admin/inventory/{box}', 'editBox')->name('admin.inventory.edit');;
-    Route::delete('/admin/inventory/{box}', 'deleteBox')->name('admin.inventory.delete');;
-
+    Route::post('/admin/inventory/{box}', 'editBox')->name('admin.inventory.edit');
+    Route::delete('/admin/inventory/{box}', 'deleteBox')->name('admin.inventory.delete');
+    Route::get('/admin/reports','reports')->name('admin.reports');
 });
 
 Route::post('/admin/inventory/{box}', [AdminController::class, 'editBox'])->name('admin.inventory.edit');

--- a/routes/web.php
+++ b/routes/web.php
@@ -145,10 +145,13 @@ Route::middleware(IsAdmin::class)->controller(AdminController::class)->group(fun
     Route::patch('/admin/orders','updateOrderStatus');
     Route::get('/admin/products', 'products')->name('admin.products');
     Route::post('/admin/products','addProduct');
-    Route::post('/admin/inventory/{box}', 'editBox');
-    Route::delete('/admin/inventory/{box}', 'deleteBox');
+    Route::post('/admin/inventory/{box}', 'editBox')->name('admin.inventory.edit');;
+    Route::delete('/admin/inventory/{box}', 'deleteBox')->name('admin.inventory.delete');;
 
 });
+
+Route::post('/admin/inventory/{box}', [AdminController::class, 'editBox'])->name('admin.inventory.edit');
+Route::delete('/admin/inventory/{box}', [AdminController::class, 'deleteBox'])->name('admin.inventory.delete');
 
 // Update customer roles
 Route::put('/update-user-role/{id}', function(Request $request, $id) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -141,7 +141,7 @@ Route::middleware(IsAdmin::class)->controller(AdminController::class)->group(fun
     Route::get('/admin/orders', 'orders')->name('admin.orders');
     Route::get('/admin/inventory', 'inventory')->name('admin.inventory');
     Route::get('/admin/inventory/{box}', 'editInventory')->name('inventory.edit');
-
+    Route::get('/admin/inventory/{box}/add', 'addInventory')->name('inventory.add');
     Route::patch('/admin/orders','updateOrderStatus');
     Route::get('/admin/products', 'products')->name('admin.products');
     Route::post('/admin/products','addProduct');


### PR DESCRIPTION
- Total rework/revamp/overhaul of the admin pages - modern, sleek and aesthetically pleasing!!!!!!

- Randomised the user images instead of keeping an ugly cow for all of them
- Changed test user's pfp to horse because horses are cool
- Fixed user pfp images not showing on the admin pages

- Redesigned customer detail management page to be more "modern" - yuck.
- Added a fake phone number for the seeded data
- Checked if user is themselves on the admin customer page - they can't change their own role
- Added a pfp of the user on the account layout page
- Redesigned the javascript buttons on the customer detail management
- Fixed the user pfp images on the customer show page

- Gave the inventory page an entire overhaul
- Added an increase stock by 1 button for all boxes
- Moved stock indicator under the search filters, if statements and gave separate divisions and background colours
- Tags for boxes are now separated! (Looks very fancy)
- Description shows two lines then includes an ellipsis
- Edit button is the same as others!
- Responsive for all devices!
- I spent too much time on this help - erm

- Fixed bug where adding a new product won't work
- Total redesign on the add new products page
- Added script that displays the image uploaded as a preview
- Changed up the edit inventory box page
- Responsive!

- Added report dashboard page, includes: total users, total admins, total orders, average order value, returned orders amount, return rate, total revenue, total inventory value, total inventory items, total enquiries, total product reviews, average product rating, total site reviews and average site rating.
- Pie chart displaying the category sales!
- This page will be used by admins to monitor their site with visually pleasing stats and ease of access